### PR TITLE
Use literal tabs

### DIFF
--- a/config-parser.sh
+++ b/config-parser.sh
@@ -9,7 +9,7 @@ config_parser () {
 	cp $iniFile $tmpFile;
 
 	# remove tabs or spaces around the =
-	$binSED -i -e 's/[ \t]*=[ \t]*/=/g' $tmpFile;
+	$binSED -i -e 's/[ 	]*=[ 	]*/=/g' $tmpFile;
 
 	# transform section labels into function declaration
 	$binSED -i -e 's/\[\([A-Za-z0-9_]*\)\]/config.section.\1() \{/g' $tmpFile;


### PR DESCRIPTION
Seems Apple's sed has trouble handling the escaped version of a tab.
Need to use a literal tab character instead. GNU sed doesn't have this
problem.

Fixes issue #4
