### PR TITLE
Fix quotation handling bug

### DIFF
--- a/config-parser.sh
+++ b/config-parser.sh
@@ -2,7 +2,7 @@ parse_ini() {
   [[ -z "$1" || -e "$1" ]] || return 1
   local system_sed=$(which sed)
   local safe_name_replace='s/[ 	]*$//;s/[^a-zA-Z0-9_]/_/g'
-  local trimming="s/^[ 	\"';]*//;s/[ 	\"';]*$//"
+  local trimming="s/^[\"']\(.*\)[\"'][;]*$/\1/;s/\"/\\\\\"/g"
   echo "config.global() {"
   echo "  :"
   cat ${1:--} | \

--- a/test/config_parse.bats
+++ b/test/config_parse.bats
@@ -38,8 +38,19 @@ setup() {
 }
 
 @test "Handles unquoted values" {
-  config.section.unquoted
-  [ "$foofoofoo" = "echo echo echo" ]
+  config.section.quotes
+  [ "$foo" = "echo echo echo" ]
+}
+
+@test "Handles unquoted values with quotes" {
+  config.section.quotes
+  [ "$foofoo" = "echo 'echo'" ]
+  [ "$foofoofoo" = "echo \"echo\"" ]
+}
+
+@test "Handles quotes in quoted values" {
+  config.section.quotes
+  [ "$quotedfoo" = "test 'quotes'" ]
 }
 
 @test "Handles trailing semi-colons" {

--- a/test/fixtures/example.ini
+++ b/test/fixtures/example.ini
@@ -18,8 +18,11 @@ foofoofoo="works"
 [test]
 foofoofoo="works-again"
 
-[unquoted]
-foofoofoo=echo echo echo
+[quotes]
+foo=echo echo echo
+foofoo=echo 'echo'
+foofoofoo=echo "echo"
+quotedfoo="test 'quotes'"
 
 [semicolons]
 foofoofoo="semicolons work";


### PR DESCRIPTION
Values such as `foo="foo 'bar'"` and `foo=foo "bar"` were not being handle correctly. This is an issue if you need to include quotes as part of your values (filenames with spaces in maybe?)
